### PR TITLE
setup.py converted to distutils, MANIFEST.in should now be complete

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
-include LICENSE
+include LICENCE
+include MANIFEST.in
 include README.rst
+include setuplib.py

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,27 @@
+#!/usr/bin/env python
+
 from distutils.core import setup
-from setuptools import find_packages
+import os
+import setuplib
+
+packages, package_data = setuplib.find_packages('scaffolding')
 
 setup(
     name='django-scaffolding',
     version='0.1.0',
     author='Simon Baechler',
     author_email='simon@stellanera.com',
-    packages=find_packages(),
-    url='https://github.com/sbaechler/django-scaffolding',
-    license='LICENSE',
+    packages=packages,
+    package_data=package_data,
+    url='https://github.com/sbaechler/django-scaffolding/',
+    license='LICENCE',
     description='Automatically generate reasonable database entries for your app',
-    long_description=open('README.rst').read(),
-    install_requires=[
-        "Django >= 1.2",
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
+    classifiers=[
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
     ],
-    zip_safe=False
 )

--- a/setuplib.py
+++ b/setuplib.py
@@ -1,0 +1,57 @@
+import os
+
+
+__all__ = ['find_files']
+
+
+def fullsplit(path, result=None):
+    """
+    Split a pathname into components (the opposite of os.path.join) in a
+    platform-neutral way.
+    """
+    if result is None:
+        result = []
+    head, tail = os.path.split(path)
+    if head == '':
+        return [tail] + result
+    if head == path:
+        return result
+    return fullsplit(head, [tail] + result)
+
+
+def find_packages(package_dir):
+    """
+    Returns a tuple consisting of a ``packages`` list and a ``package_data``
+    dictionary suitable for passing on to ``distutils.core.setup``
+
+    Requires the folder name containing the package files; ``find_files``
+    assumes that ``setup.py`` is located in the same folder as the folder
+    containing those files.
+
+    Code lifted from Django's ``setup.py``, with improvements by PSyton.
+    """
+
+    # Compile the list of packages available, because distutils doesn't have
+    # an easy way to do this.
+    packages = []
+    package_data = {}
+    root_dir = os.path.dirname(__file__)
+    if root_dir != '':
+        os.chdir(root_dir)
+
+    for dirpath, dirnames, filenames in sorted(os.walk(package_dir)):
+        # Ignore dirnames that start with '.'
+        for i, dirname in enumerate(dirnames):
+            if dirname.startswith('.'): del dirnames[i]
+        if '__init__.py' in filenames:
+            packages.append('.'.join(fullsplit(dirpath)))
+        elif filenames:
+            cur_pack = packages[0] # Assign all data files to the toplevel package
+            if cur_pack not in package_data:
+                package_data[cur_pack] = []
+            package_dir = "/".join(cur_pack.split(".")) + "/"
+            for f in filenames:
+                package_data[cur_pack].append(os.path.join(dirpath.replace(package_dir, ""), f))
+
+    return packages, package_data
+


### PR DESCRIPTION
Btw, license='LICENSE' is not exactly helpful. What's the name of the license you used to publish django-scaffolding? I use the BSD license most of the time, therefore it's `license='BSD License'` -- you should put a meaningful name in there, not the LICENCE file name.

Btw2, any reason the license's filename is LICENCE? Both spellings are correct of course, it's just that licen_s_e seems to be more common in the programming world.

Thanks!
